### PR TITLE
Fix global font size

### DIFF
--- a/swiftbible/Views/Bible/NoteModalView.swift
+++ b/swiftbible/Views/Bible/NoteModalView.swift
@@ -15,13 +15,15 @@ struct NoteModalView: View {
     var onCancel: () -> Void
     var onDelete: (Note) -> Void
 
+    @AppStorage("fontName") private var fontName: String = "Helvetica"
+    @AppStorage("fontSize") private var fontSize: Int = 20
+
     var body: some View {
         NavigationView {
             VStack {
                 Form {
                     Section(header: Text("Note Details")) {
                         Text("\(note.version.uppercased()) \(note.book) \(note.chapter):\(note.startingVerse)")
-                            .font(.headline)
                     }
 
                     Section(header: Text("Note")) {
@@ -48,6 +50,7 @@ struct NoteModalView: View {
                     .foregroundColor(.red)
                 }
             }
+            .font(Font.custom(fontName, size: CGFloat(fontSize)))
             .navigationBarTitle("Edit Note", displayMode: .inline)
             .navigationBarItems(trailing: EmptyView())
         }

--- a/swiftbible/Views/Daily Devotional/DailyDevotionalView.swift
+++ b/swiftbible/Views/Daily Devotional/DailyDevotionalView.swift
@@ -16,6 +16,7 @@ struct DailyDevotional: Decodable {
 
 struct DailyDevotionalView: View {
     @AppStorage("fontSize") private var fontSize: Int = 20
+    @AppStorage("fontName") private var fontName: String = "Helvetica"
     @Environment(UserViewModel.self) private var userViewModel
     
     @State private var message: String = ""
@@ -56,7 +57,6 @@ struct DailyDevotionalView: View {
                         .onDisappear() { pulse = false }
                     
                     Text(fetchingMessageText(for: selectedDate))
-                        .font(.headline)
                         .transition(.opacity)
                     
                     Spacer()
@@ -114,7 +114,6 @@ struct DailyDevotionalView: View {
                         }
                     
                     Text("No devotional found for this day.")
-                        .font(.headline)
                         .opacity(showNoDevotional ? 1 : 0)
                         .animation(.easeIn.delay(0.2), value: showNoDevotional)
                     
@@ -148,7 +147,7 @@ struct DailyDevotionalView: View {
             },
             alignment: .top
         )
-        .font(Font.system(size: CGFloat(fontSize)))
+        .font(Font.custom(fontName, size: CGFloat(fontSize)))
         .onAppear {
             Task { await fetchDailyDevotional(for: selectedDate) }
         }

--- a/swiftbible/Views/Search/SearchDetailView.swift
+++ b/swiftbible/Views/Search/SearchDetailView.swift
@@ -49,12 +49,11 @@ struct SearchDetailView: View {
                         }) {
                             VStack(alignment: .leading) {
                                 Text("\(result.bookName) \(result.chapterNumber):\(result.verseNumber)")
-                                    .font(Font.custom(fontName, size: CGFloat(fontSize)))
-                                    .font(.headline)
+                                    .bold()
                                 ParagraphView(firstVerseNumber: result.verseNumber, paragraph: result.verseText)
-                                    .font(.subheadline)
                                     .lineLimit(5)
                             }
+                            .font(Font.custom(fontName, size: CGFloat(fontSize)))
                         }
                     }
                     .buttonStyle(.plain)

--- a/swiftbible/Views/Settings/AuthenticateView.swift
+++ b/swiftbible/Views/Settings/AuthenticateView.swift
@@ -15,6 +15,9 @@ struct AuthenticateView: View {
     @State private var showDeleteConfirmation = false
     @State private var isDeleting = false
 
+    @AppStorage("fontName") private var fontName: String = "Helvetica"
+    @AppStorage("fontSize") private var fontSize: Int = 20
+
     @Environment(UserViewModel.self) private var userViewModel
     @AppStorage("supabaseAccessToken") private var supabaseAccessToken: String?
     @AppStorage("supabaseRefreshToken") private var supabaseRefreshToken: String?
@@ -25,7 +28,7 @@ struct AuthenticateView: View {
                 if let user = userViewModel.user {
                     VStack(alignment: .leading, spacing: 10) {
                         Text("Signed in as: \(user.email ?? "")")
-                            .font(.headline)
+                            .font(Font.custom(fontName, size: CGFloat(fontSize)))
 
                         Button("Sign Out") {
                             Task {

--- a/swiftbible/Views/Settings/SeeHighlightsView.swift
+++ b/swiftbible/Views/Settings/SeeHighlightsView.swift
@@ -12,6 +12,9 @@ import SwiftData
 struct SeeHighlightsView: View {
     @Environment(AppViewModel.self) private var appViewModel
 
+    @AppStorage("fontName") private var fontName: String = "Helvetica"
+    @AppStorage("fontSize") private var fontSize: Int = 20
+
     @Query private var highlightedVerses: [HighlightedVerse] = []
 
     @Binding var selectedTab: Tabs
@@ -34,12 +37,10 @@ struct SeeHighlightsView: View {
                         }) {
                             VStack(alignment: .leading) {
                                 Text("\(highlightedVerse.version.uppercased()) \(highlightedVerse.book) \(highlightedVerse.chapter):\(highlightedVerse.startingVerse)")
-                                    .font(.headline)
-
                                 Text("Created: \(highlightedVerse.created.formatted(date: .long, time: .omitted))")
-                                    .font(.caption)
                                     .foregroundColor(.gray)
                             }
+                            .font(Font.custom(fontName, size: CGFloat(fontSize)))
                         }
                     }
                 }

--- a/swiftbible/Views/Settings/SeeSavedNotesView.swift
+++ b/swiftbible/Views/Settings/SeeSavedNotesView.swift
@@ -11,6 +11,9 @@ import SwiftData
 
 struct SeeSavedNotesView: View {
     @Environment(AppViewModel.self) private var appViewModel
+
+    @AppStorage("fontName") private var fontName: String = "Helvetica"
+    @AppStorage("fontSize") private var fontSize: Int = 20
     
     @Query private var notes: [Note] = []
 
@@ -34,18 +37,16 @@ struct SeeSavedNotesView: View {
                         }) {
                             VStack(alignment: .leading) {
                                 Text(note.text)
-                                    .font(.headline)
                                 
                                 
                                 Text("\(note.version.uppercased()) \(note.book) \(note.chapter):\(note.startingVerse)")
-                                    .font(.headline)
-                                    .font(.subheadline)
                                     .foregroundColor(.gray)
                                 
                                 Text("Created: \(note.created.formatted(date: .long, time: .omitted))")
-                                    .font(.caption)
                                     .foregroundColor(.gray)
                             }
+                            .font(Font.custom(fontName, size: CGFloat(fontSize)))
+
                         }
                     }
                 }

--- a/swiftbible/Views/Settings/SettingsView.swift
+++ b/swiftbible/Views/Settings/SettingsView.swift
@@ -14,6 +14,9 @@ struct SettingsView: View {
     @AppStorage("hideNavAndTab") var hideNavAndTab = false
     @AppStorage("showApocrypha") var showApocrypha = false
 
+    @AppStorage("fontName") private var fontName: String = "Helvetica"
+    @AppStorage("fontSize") private var fontSize: Int = 20
+
     @Binding var selectedTab: Tabs
 
     var body: some View {
@@ -83,8 +86,8 @@ struct SettingsView: View {
                     HStack {
                         Spacer()
                         Text("Version \(Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "")")
-                            .font(.footnote)
                             .foregroundColor(.gray)
+                            .font(Font.custom(fontName, size: CGFloat(fontSize - 4)))
                         Spacer()
                     }
                 }


### PR DESCRIPTION
## Summary
- ensure font size preference is used across screens
- apply custom fonts in search results
- tweak authentication, note, and highlight views to use chosen font
- use preferred font when viewing daily devotionals

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*

------
https://chatgpt.com/codex/tasks/task_e_684995c525888325901e811d58c0d5de