### PR TITLE
Address CodeRabbit feedback (holiday URL keys, stale tab flag, verse ranges, script timeout)

### DIFF
--- a/scripts/backfill_devotional_metadata.py
+++ b/scripts/backfill_devotional_metadata.py
@@ -81,7 +81,7 @@ HOLIDAY_WIKIPEDIA_URLS = {
     "St. Patrick's Day": "https://en.wikipedia.org/wiki/Saint_Patrick%27s_Day",
     "Earth Day": "https://en.wikipedia.org/wiki/Earth_Day",
     "Flag Day": "https://en.wikipedia.org/wiki/Flag_Day_(United_States)",
-    "Patriot Day": "https://en.wikipedia.org/wiki/Patriot_Day_(United_States)",
+    "Patriot Day": "https://en.wikipedia.org/wiki/Patriot_Day",
     "International Day of Peace": "https://en.wikipedia.org/wiki/International_Day_of_Peace",
     "Michaelmas": "https://en.wikipedia.org/wiki/Michaelmas",
     "Spring Equinox": "https://en.wikipedia.org/wiki/March_equinox",

--- a/skills/custom-devotional-crafter/scripts/compose_custom_devotional.py
+++ b/skills/custom-devotional-crafter/scripts/compose_custom_devotional.py
@@ -18,7 +18,10 @@ OLD_TESTAMENT_BOOKS = {
     "habakkuk", "zephaniah", "haggai", "zechariah", "malachi",
 }
 
-VERSE_RE = re.compile(r"^\s*(?P<book>.+?)\s+(?P<chapter>\d+):(?P<verse>\d+)(?:-\d+)?\s*$", re.IGNORECASE)
+VERSE_RE = re.compile(
+    r"^\s*(?P<book>.+?)\s+(?P<chapter>\d+):(?P<verse>\d+)(?:-(?P<verse_end>\d+))?\s*$",
+    re.IGNORECASE,
+)
 
 
 @dataclass
@@ -27,6 +30,13 @@ class VerseRef:
     chapter: int
     verse: int
     testament: str
+    verse_end: int | None = None
+
+    @property
+    def reference(self) -> str:
+        if self.verse_end and self.verse_end > self.verse:
+            return f"{self.book} {self.chapter}:{self.verse}-{self.verse_end}"
+        return f"{self.book} {self.chapter}:{self.verse}"
 
 
 def normalize_book(book: str) -> str:
@@ -40,17 +50,29 @@ def detect_testament(book: str) -> str:
 def parse_verse(raw: str) -> VerseRef:
     match = VERSE_RE.match(raw)
     if not match:
-        raise ValueError(f"Invalid verse format: '{raw}'. Use e.g. 'Romans 5:3' or 'Psalm 23:1'.")
+        raise ValueError(f"Invalid verse format: '{raw}'. Use e.g. 'Romans 5:3' or 'Romans 5:3-5'.")
 
     book = normalize_book(match.group("book"))
     chapter = int(match.group("chapter"))
     verse = int(match.group("verse"))
+    end_raw = match.group("verse_end")
+    verse_end = int(end_raw) if end_raw else None
+    if verse_end is not None and verse_end <= verse:
+        raise ValueError(
+            f"Invalid verse range: '{raw}'. End verse must be greater than start verse."
+        )
     testament = detect_testament(book)
-    return VerseRef(book=book, chapter=chapter, verse=verse, testament=testament)
+    return VerseRef(
+        book=book,
+        chapter=chapter,
+        verse=verse,
+        testament=testament,
+        verse_end=verse_end,
+    )
 
 
 def build_markdown(title: str, verses: list[VerseRef], theme: str, audience: str, tone: str) -> str:
-    verse_lines = "\n".join([f"- **{v.book} {v.chapter}:{v.verse}**" for v in verses])
+    verse_lines = "\n".join([f"- **{v.reference}**" for v in verses])
     return f"""# {title}
 
 ## Scripture Focus
@@ -99,7 +121,10 @@ def main() -> None:
         "message": markdown,
         "testament": verses[0].testament,
         "devotional_type": "custom",
-        "verses": [v.__dict__ for v in verses],
+        "verses": [
+            {k: val for k, val in v.__dict__.items() if val is not None}
+            for v in verses
+        ],
     }
     if args.series_name:
         payload["series_name"] = args.series_name

--- a/skills/custom-devotional-crafter/scripts/push_custom_devotional.py
+++ b/skills/custom-devotional-crafter/scripts/push_custom_devotional.py
@@ -8,6 +8,7 @@ import json
 import os
 import sys
 import urllib.error
+import urllib.parse
 import urllib.request
 from pathlib import Path
 
@@ -39,6 +40,12 @@ def main() -> None:
     if not supabase_url or not service_role:
         raise SystemExit("Set SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY (or SUPABASE_SERVICE_KEY)")
 
+    parsed = urllib.parse.urlparse(supabase_url)
+    if parsed.scheme not in ("http", "https"):
+        raise SystemExit(
+            f"SUPABASE_URL must use http(s); got scheme '{parsed.scheme}'."
+        )
+
     endpoint = f"{supabase_url.rstrip('/')}/rest/v1/Daily%20Devotional?on_conflict=for_date"
     body = json.dumps(payload).encode("utf-8")
 
@@ -55,7 +62,9 @@ def main() -> None:
     )
 
     try:
-        with urllib.request.urlopen(req) as response:
+        # 30s is plenty for a single REST upsert; without a timeout a
+        # stalled endpoint would hang the script indefinitely.
+        with urllib.request.urlopen(req, timeout=30) as response:
             output = response.read().decode("utf-8")
             print("Success:", response.status)
             print(output)

--- a/supabase/functions/daily-devotional/index.ts
+++ b/supabase/functions/daily-devotional/index.ts
@@ -34,44 +34,67 @@ interface Holiday {
 
 // Wikipedia URLs for holiday names. Looked up by Holiday.name in
 // getHoliday() and attached to the returned object so we don't have to
-// edit every holiday literal. Names not present here just get no link.
+// edit every holiday literal. Keys MUST exactly match the .name values
+// returned by getHolidayInternal — names not present here just get no
+// link. All URLs verified live (HTTP 200) on 2026-04-26.
 const HOLIDAY_WIKIPEDIA_URLS: Record<string, string> = {
+  // Easter cycle
   "Shrove Tuesday": "https://en.wikipedia.org/wiki/Shrove_Tuesday",
   "Ash Wednesday": "https://en.wikipedia.org/wiki/Ash_Wednesday",
   "Laetare Sunday": "https://en.wikipedia.org/wiki/Laetare_Sunday",
   "Palm Sunday": "https://en.wikipedia.org/wiki/Palm_Sunday",
   "Holy Monday": "https://en.wikipedia.org/wiki/Holy_Monday",
-  "Holy Tuesday": "https://en.wikipedia.org/wiki/Holy_Tuesday",
-  "Holy Wednesday": "https://en.wikipedia.org/wiki/Holy_Wednesday",
+  "Spy Wednesday": "https://en.wikipedia.org/wiki/Holy_Wednesday",
   "Maundy Thursday": "https://en.wikipedia.org/wiki/Maundy_Thursday",
   "Good Friday": "https://en.wikipedia.org/wiki/Good_Friday",
   "Holy Saturday": "https://en.wikipedia.org/wiki/Holy_Saturday",
   "Easter Sunday": "https://en.wikipedia.org/wiki/Easter",
-  "Easter Monday": "https://en.wikipedia.org/wiki/Easter_Monday",
   "Ascension Day": "https://en.wikipedia.org/wiki/Feast_of_the_Ascension",
   "Pentecost": "https://en.wikipedia.org/wiki/Pentecost",
   "Trinity Sunday": "https://en.wikipedia.org/wiki/Trinity_Sunday",
-  "Corpus Christi": "https://en.wikipedia.org/wiki/Feast_of_Corpus_Christi",
+  // Fixed-date Christian
   "Epiphany": "https://en.wikipedia.org/wiki/Epiphany_(holiday)",
-  "Baptism of the Lord": "https://en.wikipedia.org/wiki/Baptism_of_the_Lord",
-  "Annunciation": "https://en.wikipedia.org/wiki/Feast_of_the_Annunciation",
+  "Epiphany Eve": "https://en.wikipedia.org/wiki/Epiphany_(holiday)",
+  "Baptism of Jesus": "https://en.wikipedia.org/wiki/Baptism_of_the_Lord",
   "Transfiguration": "https://en.wikipedia.org/wiki/Feast_of_the_Transfiguration",
-  "Assumption of Mary": "https://en.wikipedia.org/wiki/Assumption_of_Mary",
-  "All Saints' Day": "https://en.wikipedia.org/wiki/All_Saints%27_Day",
-  "All Souls' Day": "https://en.wikipedia.org/wiki/All_Souls%27_Day",
   "Reformation Day": "https://en.wikipedia.org/wiki/Reformation_Day",
-  "Christ the King": "https://en.wikipedia.org/wiki/Feast_of_Christ_the_King",
-  "Advent": "https://en.wikipedia.org/wiki/Advent",
+  "All Saints' Day": "https://en.wikipedia.org/wiki/All_Saints%27_Day",
   "Christmas Eve": "https://en.wikipedia.org/wiki/Christmas_Eve",
   "Christmas Day": "https://en.wikipedia.org/wiki/Christmas",
-  "Holy Innocents": "https://en.wikipedia.org/wiki/Massacre_of_the_Innocents",
+  "New Year's Eve": "https://en.wikipedia.org/wiki/New_Year%27s_Eve",
   "New Year's Day": "https://en.wikipedia.org/wiki/New_Year%27s_Day",
-  "Thanksgiving": "https://en.wikipedia.org/wiki/Thanksgiving_(United_States)",
+  "Christ the King Sunday": "https://en.wikipedia.org/wiki/Feast_of_Christ_the_King",
+  // Advent — each Sunday is a distinct .name
+  "First Sunday of Advent": "https://en.wikipedia.org/wiki/Advent",
+  "Second Sunday of Advent": "https://en.wikipedia.org/wiki/Advent",
+  "Third Sunday of Advent": "https://en.wikipedia.org/wiki/Advent",
+  "Fourth Sunday of Advent": "https://en.wikipedia.org/wiki/Advent",
+  // Moveable secular
   "Mother's Day": "https://en.wikipedia.org/wiki/Mother%27s_Day",
   "Father's Day": "https://en.wikipedia.org/wiki/Father%27s_Day",
-  "Independence Day": "https://en.wikipedia.org/wiki/Independence_Day_(United_States)",
+  "Thanksgiving": "https://en.wikipedia.org/wiki/Thanksgiving_(United_States)",
+  "Martin Luther King Jr. Day": "https://en.wikipedia.org/wiki/Martin_Luther_King_Jr._Day",
+  "Presidents' Day": "https://en.wikipedia.org/wiki/Washington%27s_Birthday",
   "Memorial Day": "https://en.wikipedia.org/wiki/Memorial_Day",
+  "Labor Day": "https://en.wikipedia.org/wiki/Labor_Day",
+  "Election Day": "https://en.wikipedia.org/wiki/Election_Day_(United_States)",
+  "World Day of Prayer": "https://en.wikipedia.org/wiki/World_Day_of_Prayer",
+  "National Day of Prayer": "https://en.wikipedia.org/wiki/National_Day_of_Prayer",
+  // Fixed-date secular & seasonal
+  "Independence Day": "https://en.wikipedia.org/wiki/Independence_Day_(United_States)",
+  "Juneteenth": "https://en.wikipedia.org/wiki/Juneteenth",
   "Veterans Day": "https://en.wikipedia.org/wiki/Veterans_Day",
+  "Valentine's Day": "https://en.wikipedia.org/wiki/Valentine%27s_Day",
+  "St. Patrick's Day": "https://en.wikipedia.org/wiki/Saint_Patrick%27s_Day",
+  "Earth Day": "https://en.wikipedia.org/wiki/Earth_Day",
+  "Flag Day": "https://en.wikipedia.org/wiki/Flag_Day_(United_States)",
+  "Patriot Day": "https://en.wikipedia.org/wiki/Patriot_Day",
+  "International Day of Peace": "https://en.wikipedia.org/wiki/International_Day_of_Peace",
+  "Michaelmas": "https://en.wikipedia.org/wiki/Michaelmas",
+  "Spring Equinox": "https://en.wikipedia.org/wiki/March_equinox",
+  "Summer Solstice": "https://en.wikipedia.org/wiki/Summer_solstice",
+  "Autumn Equinox": "https://en.wikipedia.org/wiki/September_equinox",
+  "Winter Solstice": "https://en.wikipedia.org/wiki/Winter_solstice",
 };
 
 // ─── Load local KJV Bible data ──────────────────────────────────────

--- a/swiftbible/Views/ContentView.swift
+++ b/swiftbible/Views/ContentView.swift
@@ -198,6 +198,7 @@ struct ContentView: View {
                 }
 
                 evaluateDonationPrompt()
+                await refreshTodayDevotionalType()
                 await refreshDevotionalReminders()
 
                 // Mark app as no longer launching after initial load
@@ -227,7 +228,10 @@ struct ContentView: View {
         .onChange(of: scenePhase) { _, newPhase in
             handleScenePhaseChange(newPhase)
             if newPhase == .active {
-                Task { await refreshDevotionalReminders() }
+                Task {
+                    await refreshTodayDevotionalType()
+                    await refreshDevotionalReminders()
+                }
             }
         }
         .onChange(of: donationPromptOptOut) { _, newValue in
@@ -675,6 +679,44 @@ struct ContentView: View {
             donationErrorMessage = error.localizedDescription
         }
         showDonationErrorAlert = true
+    }
+
+    /// Keep `todayDevotionalIsCustom` in sync with whatever's on the
+    /// server for today's date — independent of reminders. Without
+    /// this, the tab title can stick on "Custom" after a day rollover
+    /// until the user opens the Devotional tab.
+    private func refreshTodayDevotionalType() async {
+        let today = Date()
+        if let cached = CacheService.shared.loadDevotional(for: today) {
+            await MainActor.run {
+                todayDevotionalIsCustom = (cached.devotional_type == "custom")
+            }
+            return
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        let dateString = formatter.string(from: today)
+
+        do {
+            let devotional: DailyDevotional = try await SupabaseService.shared.client
+                .from("Daily Devotional")
+                .select()
+                .eq("for_date", value: dateString)
+                .single()
+                .execute()
+                .value
+            CacheService.shared.saveDevotional(devotional, for: today)
+            await MainActor.run {
+                todayDevotionalIsCustom = (devotional.devotional_type == "custom")
+            }
+        } catch {
+            // No devotional yet — clear the flag so we don't show a
+            // stale "Custom" tab title from a previous day.
+            await MainActor.run {
+                todayDevotionalIsCustom = false
+            }
+        }
     }
 
     /// Prefetch today's devotional and reschedule the notification with fresh content.


### PR DESCRIPTION
## Summary

Fixes the actionable items from CodeRabbit's review of #28:

- **Holiday URL key mismatches** — several entries in `HOLIDAY_WIKIPEDIA_URLS` didn't match the `.name` values returned by `getHolidayInternal` (e.g. `"Holy Wednesday"` vs. actual `"Spy Wednesday"`, missing keys for the four Advent Sundays). Future holiday devotionals on those days were silently shipping with null `holiday_url`. Keys realigned, dead keys removed, missing keys added (MLK, Juneteenth, equinoxes, etc.).
- **All 48 URLs verified live** with HTTP 200 (Patriot Day was 404'd → corrected; affected prod rows patched directly).
- **Stale `todayDevotionalIsCustom` flag** — the Devotional tab could stick on "Custom" with the pencil icon after a day rollover until the user opened the tab. Now refreshed on launch and on scenePhase active, independent of the reminder-enabled flag.
- **Verse range capture** in `compose_custom_devotional.py` — `"Romans 5:3-5"` was being silently truncated to `5:3`. Now preserved in both the rendered markdown and the JSON `verses` payload.
- **Push script hardening** — added 30s `urlopen` timeout and HTTP(S) scheme validation on `SUPABASE_URL`.

Skipped from the review (deferred / scope-out):
- CodingKeys refactor on `DailyDevotional`: pre-existing fields are already snake_case throughout the codebase; no SwiftLint failure today.
- VoiceOver wrapping of theme-context rows: better as a broader accessibility pass.
- Markdownlint MD040 / RUNBOOK example verse alignment: cosmetic.

## Test plan

- [x] All 48 holiday Wikipedia URLs HTTP 200
- [x] Patriot Day prod rows patched (2024-09-11, 2025-09-11)
- [x] compose script with `--verse "Romans 5:3-5"` produces correct JSON + markdown
- [x] push script `--dry-run` still works (smoke-tested)
- [ ] Verify in next TestFlight that tab title flips correctly after midnight
- [ ] Verify holiday wiki link appears for Spy Wednesday, Advent Sundays, Christ the King Sunday, Baptism of Jesus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for verse ranges in custom devotionals (e.g., "John 3:16-18").

* **Bug Fixes**
  * Fixed stale devotional type display after date rollover.
  * Enhanced reliability with network timeout protection for devotional uploads.
  * Improved holiday-to-reference mappings for accurate Wikipedia links.
  * Corrected Patriot Day reference URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->